### PR TITLE
fix : 검색 수정

### DIFF
--- a/src/main/java/com/example/vblogserver/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/vblogserver/domain/board/repository/BoardRepository.java
@@ -31,7 +31,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     List<Board> findByIdInAndCategoryG_CategoryNameIgnoreCase(List<Long> ids, String categoryName);
 
-    List<Board> findByHashtagContainingOrDescriptionContainingOrTitleContaining(String hashtag, String description, String title);
+    //검색용.
+    List<Board> findByHashtagContainingOrderByCreatedDateDesc(String hashtag);
 
     Page<Board> findByFolderAndCategoryG_CategoryNameIgnoreCase(Folder folder, String type, PageRequest pageRequest);
 

--- a/src/main/java/com/example/vblogserver/domain/board/service/main/DTOConvertServcie.java
+++ b/src/main/java/com/example/vblogserver/domain/board/service/main/DTOConvertServcie.java
@@ -38,8 +38,6 @@ public class DTOConvertServcie {
         if (board.getReviewCount() != null) {
             clientDataDTO.setReview(board.getReviewCount());
         }
-        System.out.println("convertToClientDataDTO() : "+board.getId());
-
 
         return clientDataDTO;
     }


### PR DESCRIPTION
- 기존 검색 api 는 '해시태그+제목+내용'을 기준으로 검색어와 연관성 있는 게시글을 반환. 수정 내용 : '해시태그'를 기준으로 연관성 있는 게시글을 반환
- 검색 시 연관검색어에 노출될 해시태그를 검색하는 api 추가